### PR TITLE
post_header with s.query()

### DIFF
--- a/solr/core.py
+++ b/solr/core.py
@@ -419,6 +419,7 @@ class Solr:
 
         self.form_headers = {
             'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'}
+        self.form_headers.update(post_headers)
         
         if http_user is not None and http_pass is not None:
             http_auth = http_user + ':' + http_pass


### PR DESCRIPTION
https://code.google.com/p/solrpy/issues/detail?id=34

What steps will reproduce the problem?

```
>>> import solr
>>> s = solr.SolrConnection('https://example.com/solr', post_headers={'x-api-key': 'xxxyyyzzz'})
>>> s.query("fred")
```

What is the expected output? What do you see instead?

I expect to see the x-api-key header on the server side

What version of the product are you using? On what operating system?
`pip install solrpy` version on OS X

Please provide any additional information below.

here is a patch that fixes it for me

https://code.google.com/r/briantinglecdliborg-solrpyx/source/detail?r=d83b854e3b301aa1f433e52c7c5e617c1b4b303e

