### PR TITLE
Fix solrpy test to succeed in Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,9 @@ language: python
 before_script: curl -sSL https://raw.githubusercontent.com/moliware/travis-solr/master/travis-solr.sh | SOLR_VERSION=4.10.3 SOLR_CONFS=tests bash
 script: python setup.py test
 python:
+  - "3.7"
+  - "3.6"
+  - "3.5"
+  - "3.4"
   - "2.7"
   - "2.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 before_script: curl -sSL https://raw.githubusercontent.com/moliware/travis-solr/master/travis-solr.sh | SOLR_VERSION=4.10.3 SOLR_CONFS=tests bash
 script: python setup.py test
 python:
-  - "3.7"
   - "3.6"
   - "3.5"
   - "3.4"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 # bootstrap easy_install
-import ez_setup
-ez_setup.use_setuptools()
+import sys
+
+if sys.version_info[0] == 2:
+    import ez_setup
+    ez_setup.use_setuptools()
 
 from setuptools import setup, find_packages
 import solr.core
@@ -12,8 +15,8 @@ setup(
     url = 'http://code.google.com/p/solrpy',
     license = 'http://opensource.org/licenses/apache2.0.php',
     packages=find_packages(),
-    install_requires = [],
+    install_requires = ["future", "six"],
     description = 'Client for the Solr search service',
-    tests_require = ["nose>=0.10.1"],
+    tests_require = ["nose>=0.10.1", "future", "six"],
     test_suite = 'nose.collector',
     )

--- a/solr/__init__.py
+++ b/solr/__init__.py
@@ -1,2 +1,8 @@
-from core import *
-from paginator import *
+import sys
+
+if sys.version_info[0] == 3:
+    from solr.core import *
+    from solr.paginator import *
+else:
+    from core import *
+    from paginator import *

--- a/solr/core.py
+++ b/solr/core.py
@@ -252,9 +252,9 @@ except ImportError:
 try:
     from urllib.parse import urlparse, urlencode, quote, quote_plus
 except ImportError:
-    from urllib2.urlparse import urlparse
-    from urllib2 import quote
+    from urllib2 import urlparse, quote
     from urllib import urlencode, quote_plus
+    urlparse = urlparse.urlparse
 
 import codecs
 import datetime

--- a/solr/core.py
+++ b/solr/core.py
@@ -612,8 +612,12 @@ class Solr:
                 elif isinstance(value, bool):
                     value = value and 'true' or 'false'
 
-                lst.append('<field name=%s>%s</field>' % (
-                    (quoteattr(field), escape(str(value)))))
+                if six.PY3:
+                    lst.append('<field name=%s>%s</field>' % (
+                        (quoteattr(field), escape(str(value)))))
+                else:
+                    lst.append('<field name=%s>%s</field>' % (
+                        (quoteattr(field), escape(value))))
         lst.append('</doc>')
 
     def _delete(self, id=None, ids=None, queries=None):
@@ -658,6 +662,7 @@ class Solr:
         while attempts > 0:
             try:
                 self.conn.request('POST', url, body.encode('UTF-8'), _headers)
+                print(self.conn.getresponse())
                 return check_response_status(self.conn.getresponse())
             except (socket.error,
                     client.ImproperConnectionState,

--- a/solr/core.py
+++ b/solr/core.py
@@ -662,7 +662,11 @@ class Solr:
         while attempts > 0:
             try:
                 self.conn.request('POST', url, body.encode('UTF-8'), _headers)
-                print(dir(self.conn.getresponse()))
+                print(self.conn.getresponse().getheaders())
+                print(self.conn.getresponse().msg)
+                print(self.conn.getresponse().reason)
+                print(self.conn.getresponse().status)
+                print(self.conn.getresponse().version)
                 return check_response_status(self.conn.getresponse())
             except (socket.error,
                     client.ImproperConnectionState,

--- a/solr/core.py
+++ b/solr/core.py
@@ -662,11 +662,6 @@ class Solr:
         while attempts > 0:
             try:
                 self.conn.request('POST', url, body.encode('UTF-8'), _headers)
-                print(self.conn.getresponse().getheaders())
-                print(self.conn.getresponse().msg)
-                print(self.conn.getresponse().reason)
-                print(self.conn.getresponse().status)
-                print(self.conn.getresponse().version)
                 return check_response_status(self.conn.getresponse())
             except (socket.error,
                     client.ImproperConnectionState,
@@ -1140,9 +1135,14 @@ class Node(object):
 # ===================================================================
 def check_response_status(response):
     if response.status != 200:
+        print(response.msg)
+        print(response.version)
+        print(response.read())
+
         ex = SolrException(response.status, response.reason)
         try:
-            ex.body = response.read()
+            # ex.body = response.read()
+            ex.body = ""
         except:
             pass
         raise ex

--- a/solr/core.py
+++ b/solr/core.py
@@ -662,7 +662,7 @@ class Solr:
         while attempts > 0:
             try:
                 self.conn.request('POST', url, body.encode('UTF-8'), _headers)
-                print(self.conn.getresponse())
+                print(dir(self.conn.getresponse()))
                 return check_response_status(self.conn.getresponse())
             except (socket.error,
                     client.ImproperConnectionState,

--- a/solr/core.py
+++ b/solr/core.py
@@ -814,7 +814,7 @@ class SearchHandler(object):
 
         params['fl'] = fields
         params['version'] = self.conn.response_version
-        params['wt'] = 'standard'
+        params['wt'] = 'xml'
 
         xml = self.raw(**params)
         if six.PY3:

--- a/solr/core.py
+++ b/solr/core.py
@@ -252,7 +252,8 @@ except ImportError:
 try:
     from urllib.parse import urlparse, urlencode, quote, quote_plus
 except ImportError:
-    from urllib2 import urlparse, quote
+    from urllib2.urlparse import urlparse
+    from urllib2 import quote
     from urllib import urlencode, quote_plus
 
 import codecs

--- a/solr/core.py
+++ b/solr/core.py
@@ -239,15 +239,34 @@ Enter a raw query, without processing the returned HTML contents.
     >>> print c.raw_query(q='id:[* TO *]', wt='python', rows='10')
 
 """
+from __future__ import unicode_literals
+
 import sys
 import socket
-import httplib
-import urlparse
+import six
+try:
+    import httplib as client
+except ImportError:
+    import http.client as client
+
+try:
+    from urllib.parse import urlparse, urlencode, quote, quote_plus
+except ImportError:
+    from urllib2 import urlparse, quote
+    from urllib import urlencode, quote_plus
+
 import codecs
-import urllib
 import datetime
 import logging
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+long = getattr(__builtins__, 'long', int)
+basestring = getattr(__builtins__, 'basestring', str)
+unicode = getattr(__builtins__, 'unicode', str)
+
 from xml.sax import make_parser
 from xml.sax.handler import ContentHandler
 from xml.sax.saxutils import escape, quoteattr
@@ -373,7 +392,7 @@ class Solr:
 
         """
 
-        self.scheme, self.host, self.path = urlparse.urlparse(url, 'http')[:3]
+        self.scheme, self.host, self.path = urlparse(url, 'http')[:3]
         self.url = url
 
         assert self.scheme in ('http','https')
@@ -393,10 +412,10 @@ class Solr:
             kwargs['timeout'] = self.timeout
 
         if self.scheme == 'https':
-            self.conn = httplib.HTTPSConnection(self.host,
+            self.conn = client.HTTPSConnection(self.host,
                    key_file=ssl_key, cert_file=ssl_cert, **kwargs)
         else:
-            self.conn = httplib.HTTPConnection(self.host, **kwargs)
+            self.conn = client.HTTPConnection(self.host, **kwargs)
 
         self.response_version = 2.2
         self.encoder = codecs.getencoder('utf-8')
@@ -550,6 +569,8 @@ class Solr:
         try:
             rsp = self._post(selector, request, self.xmlheaders)
             data = rsp.read()
+            if six.PY3:
+                data = data.decode('utf-8')
         finally:
             if not self.persistent:
                 self.close()
@@ -591,8 +612,7 @@ class Solr:
                     value = value and 'true' or 'false'
 
                 lst.append('<field name=%s>%s</field>' % (
-                    (quoteattr(field),
-                    escape(unicode(value)))))
+                    (quoteattr(field), escape(str(value)))))
         lst.append('</doc>')
 
     def _delete(self, id=None, ids=None, queries=None):
@@ -605,9 +625,9 @@ class Solr:
             ids.insert(0, id)
         lst = []
         for id in ids:
-            lst.append(u'<id>%s</id>\n' % escape(unicode(id)))
+            lst.append(u'<id>%s</id>\n' % escape(id))
         for query in (queries or ()):
-            lst.append(u'<query>%s</query>\n' % escape(unicode(query)))
+            lst.append(u'<query>%s</query>\n' % escape(query))
         if lst:
             lst.insert(0, u'<delete>\n')
             lst.append(u'</delete>')
@@ -639,8 +659,8 @@ class Solr:
                 self.conn.request('POST', url, body.encode('UTF-8'), _headers)
                 return check_response_status(self.conn.getresponse())
             except (socket.error,
-                    httplib.ImproperConnectionState,
-                    httplib.BadStatusLine):
+                    client.ImproperConnectionState,
+                    client.BadStatusLine):
                     # We include BadStatusLine as they are spurious
                     # and may randomly happen on an otherwise fine
                     # Solr connection (though not often)
@@ -794,11 +814,13 @@ class SearchHandler(object):
 
         params['fl'] = fields
         params['version'] = self.conn.response_version
-        params['wt'] = 'xml'
+        params['wt'] = 'standard'
 
-        json = self.raw(**params)
-        return parse_query_response("XML", StringIO(json),  params, self)
-        # return parse_query_response("JSON", StringIO(json), params, self)
+        xml = self.raw(**params)
+        if six.PY3:
+            if type(xml) == bytes:
+                xml = xml.decode('utf-8')
+        return parse_query_response(StringIO(xml),  params, self)
 
     def raw(self, **params):
         """
@@ -815,7 +837,7 @@ class SearchHandler(object):
                 query.extend([(key, strify(v)) for v in value])
             else:
                 query.append((key, strify(value)))
-        request = urllib.urlencode(query, doseq=True)
+        request = urlencode(query, doseq=True)
         conn = self.conn
         if conn.debug:
             logging.info("solrpy request: %s" % request)
@@ -950,24 +972,21 @@ class Response(object):
 # ===================================================================
 # XML Parsing support
 # ===================================================================
-def parse_query_response(data_type, data, params, query):
+def parse_query_response(data, params, query):
     """
     Parse the XML results of a /select call.
     """
-    if data_type == "XML":
-        parser = make_parser()
-        handler = ResponseContentHandler()
-        parser.setContentHandler(handler)
-        parser.parse(data)
-        if handler.stack[0].children:
-            response = handler.stack[0].children[0].final
-            response._params = params
-            response._query = query
-            return response
-        else:
-            return None
-    elif data_type == "JSON":
-        pass
+    parser = make_parser()
+    handler = ResponseContentHandler()
+    parser.setContentHandler(handler)
+    parser.parse(data)
+    if handler.stack[0].children:
+        response = handler.stack[0].children[0].final
+        response._params = params
+        response._query = query
+        return response
+    else:
+        return None
 
 
 class ResponseContentHandler(ContentHandler):
@@ -1025,7 +1044,6 @@ class ResponseContentHandler(ContentHandler):
         elif name in ('float','double', 'status','QTime'):
             node.final = float(value.strip())
 
-
         elif name == 'response':
             node.final = response = Response(self)
             for child in node.children:
@@ -1048,12 +1066,19 @@ class ResponseContentHandler(ContentHandler):
                         for cnode in node.children])
 
         elif name in ('arr',):
+            is_found_str = False
+
             def node_data(node):
                 if node.name == "str":
+                    is_found_str = True
                     return "".join(node.chars)
                 else:
                     return node.final
-            node.final = [node_data(cnode) for cnode in node.children][0]
+
+            if not is_found_str:
+                node.final = [cnode.final for cnode in node.children]
+            else:
+                node.final = [node_data(cnode) for cnode in node.children][0]
 
         elif name == 'result':
             node.final = Results([cnode.final for cnode in node.children])
@@ -1172,10 +1197,10 @@ def qs_from_items(query):
     if query:
         sep = '?'
         for k, v in query.items():
-            k = urllib.quote(k)
+            k = quote(k)
             if isinstance(v, basestring):
                 v = [v]
             for s in v:
-                qs += "%s%s=%s" % (sep, k, urllib.quote_plus(s))
+                qs += "%s%s=%s" % (sep, k, quote_plus(s))
                 sep = '&'
     return qs

--- a/solr/paginator.py
+++ b/solr/paginator.py
@@ -76,10 +76,10 @@ class SolrPaginator:
         try:
             int(page_num)
         except:
-            raise 'PageNotAnInteger'
+            raise PageNotAnInteger()
 
         if page_num not in self.page_range:
-            raise 'EmptyPage', 'That page does not exist.'
+            raise EmptyPage('That page does not exist.')
 
         # Page 1 starts at 0; take one off before calculating
         start = (page_num - 1) * self.page_size
@@ -130,3 +130,10 @@ class SolrPage:
     def previous_page_number(self):
         return self.number - 1
 
+
+class PageNotAnInteger(BaseException):
+	pass
+
+
+class EmptyPage(BaseException):
+	pass

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -7,12 +7,16 @@ Meant to be run against Solr 1.2+.
 """
 
 # stdlib
-import cPickle
+import six
 import pickle
 import socket
 import datetime
 import unittest
-import httplib
+import six.moves.http_client as httplib
+from six.moves import cPickle
+from past.builtins import long
+from six import BytesIO
+from six import StringIO
 from string import digits
 from random import choice
 from xml.dom.minidom import parseString
@@ -27,6 +31,7 @@ SOLR_PORT_HTTP = "8983"
 SOLR_PORT_HTTPS = "8943"
 SOLR_HTTP = "http://" + SOLR_HOST + ":" + SOLR_PORT_HTTP  + SOLR_PATH
 SOLR_HTTPS = "https://" + SOLR_HOST + ":" + SOLR_PORT_HTTPS + SOLR_PATH
+
 
 
 def get_rand_string():
@@ -343,7 +348,11 @@ class TestAddingDocuments(SolrConnectionTestCase):
         """ Check whether Unicode data actually works for single document.
         """
         # "bile" in Polish (UTF-8).
-        data = "\xc5\xbc\xc3\xb3\xc5\x82\xc4\x87".decode("utf-8")
+        if six.PY3:
+            data = bytes("\xc5\xbc\xc3\xb3\xc5\x82\xc4\x87", "latin1").decode("utf-8")
+        else:
+            data = "\xc5\xbc\xc3\xb3\xc5\x82\xc4\x87".decode("utf-8")
+        
         doc = get_rand_userdoc(data=data)
 
         self.add(**doc)
@@ -374,8 +383,12 @@ class TestAddingDocuments(SolrConnectionTestCase):
         documents.
         """
         # Some Polish characters (UTF-8)
-        chars = ("\xc4\x99\xc3\xb3\xc4\x85\xc5\x9b\xc5\x82"
-                 "\xc4\x98\xc3\x93\xc4\x84\xc5\x9a\xc5\x81").decode("utf-8")
+        if six.PY3:
+            chars = bytes("\xc4\x99\xc3\xb3\xc4\x85\xc5\x9b\xc5\x82"
+                     "\xc4\x98\xc3\x93\xc4\x84\xc5\x9a\xc5\x81", "latin1").decode("utf-8")
+        else:
+            chars = ("\xc4\x99\xc3\xb3\xc4\x85\xc5\x9b\xc5\x82"
+                     "\xc4\x98\xc3\x93\xc4\x84\xc5\x9a\xc5\x81").decode("utf-8")
 
         documents = [get_rand_userdoc(data=char) for char in chars]
 
@@ -714,6 +727,8 @@ class TestQuerying(SolrConnectionTestCase):
 
         for result in results:
             fields = result.keys()
+            if six.PY3:
+                fields = list(fields)
             fields.remove(field_to_return)
 
             # Now there should only a score field
@@ -1192,8 +1207,8 @@ class TestSolrConnectionSearchHandler(SolrConnectionTestCase):
         conn = self.new_connection()
         conn.select("id:foobar", score=False)
         self.assertEqual(self.request_selector, SOLR_PATH + "/select")
-        self.assertEqual(self.request_body,
-                         "q=id%3Afoobar&version=2.2&fl=%2A&wt=standard")
+        self.assertEqual(sorted(self.request_body.split("&")),
+                         sorted("q=id%3Afoobar&version=2.2&fl=%2A&wt=standard".split("&")))
 
     def test_select_raw_request(self):
         conn = self.new_connection()
@@ -1206,8 +1221,8 @@ class TestSolrConnectionSearchHandler(SolrConnectionTestCase):
         alternate = solr.SearchHandler(conn, "/alternate/path")
         alternate("id:foobar", score=False)
         self.assertEqual(self.request_selector, SOLR_PATH + "/alternate/path")
-        self.assertEqual(self.request_body,
-                         "q=id%3Afoobar&version=2.2&fl=%2A&wt=standard")
+        self.assertEqual(sorted(self.request_body.split("&")),
+                         sorted("q=id%3Afoobar&version=2.2&fl=%2A&wt=standard".split("&")))
 
     def test_alternate_raw_request(self):
         conn = self.new_connection()
@@ -1349,7 +1364,7 @@ class TestPaginator(SolrConnectionTestCase):
     def test_page_range(self):
         """ Check the page range returned by the paginator """
         paginator = solr.SolrPaginator(self.result)
-        self.assertEqual(paginator.page_range, [1,2])
+        self.assertEqual(list(paginator.page_range), [1,2])
 
     def test_default_page_size(self):
         """ Test invalid/impproper default page sizes for paginator """
@@ -1384,7 +1399,10 @@ class TestPaginator(SolrConnectionTestCase):
 
     def test_unicode_query(self):
         """ Test for unicode support in subsequent paginator queries """
-        chinese_data = '\xe6\xb3\xb0\xe5\x9b\xbd'.decode('utf-8')
+        if six.PY3:
+            chinese_data = bytes('\xe6\xb3\xb0\xe5\x9b\xbd', 'latin1').decode('utf-8')
+        else:
+            chinese_data = '\xe6\xb3\xb0\xe5\x9b\xbd'.decode('utf-8')
         self.conn.add(id=100, data=chinese_data)
         self.conn.commit()
         result = self.query(self.conn, chinese_data.encode('utf-8'))
@@ -1506,7 +1524,10 @@ class TestSolrAddingDocuments(SolrBased, RequestTracking, TestAddingDocuments):
             "/update?commit=true&waitFlush=false&waitSearcher=false")
         # Can't verify the add since we said we weren't going to wait
         # for the flush.
-        self.assert_("<add>" in self.postbody())
+        if six.PY3:
+            self.assert_(b"<add>" in self.postbody())
+        else:
+            self.assert_("<add>" in self.postbody())
 
     def test_add_nosearcher(self):
         doc = get_rand_userdoc()
@@ -1517,7 +1538,10 @@ class TestSolrAddingDocuments(SolrBased, RequestTracking, TestAddingDocuments):
             "/update?commit=true&waitSearcher=false")
         # Can't verify the add since we said we weren't going to wait
         # for a searcher.
-        self.assert_("<add>" in self.postbody())
+        if six.PY3:
+            self.assert_(b"<add>" in self.postbody())
+        else:
+            self.assert_("<add>" in self.postbody())
 
     def test_add_waitflush_without_commit(self):
         doc = get_rand_userdoc()
@@ -1536,7 +1560,10 @@ class TestSolrAddingDocuments(SolrBased, RequestTracking, TestAddingDocuments):
             "/update?commit=true&waitFlush=false&waitSearcher=false")
         # Can't verify the add since we said we weren't going to wait
         # for the flush.
-        self.assert_("<add>" in self.postbody())
+        if six.PY3:
+            self.assert_(b"<add>" in self.postbody())
+        else:
+            self.assert_("<add>" in self.postbody())
 
     def test_add_many_commit_nosearcher(self):
         documents = [get_rand_userdoc() for i in range(3)]
@@ -1547,7 +1574,10 @@ class TestSolrAddingDocuments(SolrBased, RequestTracking, TestAddingDocuments):
             "/update?commit=true&waitSearcher=false")
         # Can't verify the add since we said we weren't going to wait
         # for a searcher.
-        self.assert_("<add>" in self.postbody())
+        if six.PY3:
+            self.assert_(b"<add>" in self.postbody())
+        else:
+            self.assert_("<add>" in self.postbody())
 
     def test_add_many_waitflush_without_commit(self):
         docs = [get_rand_userdoc(), get_rand_userdoc()]
@@ -1654,7 +1684,10 @@ class TestSolrDocumentDeletion(SolrBased, RequestTracking,
             "/update?commit=true&waitFlush=false&waitSearcher=false")
         # Can't verify the add since we said we weren't going to wait
         # for the flush.
-        self.assert_("<delete>" in self.postbody())
+        if six.PY3:
+            self.assert_(b"<delete>" in self.postbody())
+        else:
+            self.assert_("<delete>" in self.postbody())
 
     def test_delete_nosearcher(self):
         doc = get_rand_userdoc()
@@ -1667,7 +1700,10 @@ class TestSolrDocumentDeletion(SolrBased, RequestTracking,
             "/update?commit=true&waitSearcher=false")
         # Can't verify the add since we said we weren't going to wait
         # for the flush.
-        self.assert_("<delete>" in self.postbody())
+        if six.PY3:
+            self.assert_(b"<delete>" in self.postbody()) 
+        else:
+            self.assert_("<delete>" in self.postbody())
 
     def test_delete_waitflush_without_commit(self):
         doc = get_rand_userdoc()
@@ -1809,7 +1845,14 @@ class SolrExceptionHttpStatusPickleTestCase(unittest.TestCase):
             '\x01ub.')
 
     def _test_unpickle(self, s):
-        loaded = self.module.loads(s)
+        try:
+            loaded = self.module.loads(s)
+        except TypeError as e:
+            if six.PY3:
+                s_bytes = BytesIO()
+                s_bytes.write(s.encode('latin1'))
+                s = s_bytes.getvalue()
+            loaded = self.module.loads(s)
         self.assertEqual(loaded.httpcode, self.initial.httpcode)
         self.assertEqual(loaded.reason, self.initial.reason)
         self.assertEqual(loaded.body, self.initial.body)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -46,6 +46,11 @@ def get_rand_userdoc(id=None, user_id=None, data=None):
         }
 
 
+def query_parse(query_string):
+    uri, query_data = query_string.split("?")
+    return "{0}?{1}".format(uri, "&".join(sorted(query_data.split("&"))))
+
+
 # The names of the following two classes relate specifically to the
 # class names in solr.core.
 
@@ -1207,8 +1212,8 @@ class TestSolrConnectionSearchHandler(SolrConnectionTestCase):
         conn = self.new_connection()
         conn.select("id:foobar", score=False)
         self.assertEqual(self.request_selector, SOLR_PATH + "/select")
-        self.assertEqual(sorted(self.request_body.split("&")),
-                         sorted("q=id%3Afoobar&version=2.2&fl=%2A&wt=xml".split("&")))
+        self.assertEqual(query_parse(self.request_body),
+                         query_parse("q=id%3Afoobar&version=2.2&fl=%2A&wt=xml"))
 
     def test_select_raw_request(self):
         conn = self.new_connection()
@@ -1221,8 +1226,8 @@ class TestSolrConnectionSearchHandler(SolrConnectionTestCase):
         alternate = solr.SearchHandler(conn, "/alternate/path")
         alternate("id:foobar", score=False)
         self.assertEqual(self.request_selector, SOLR_PATH + "/alternate/path")
-        self.assertEqual(sorted(self.request_body.split("&")),
-                         sorted("q=id%3Afoobar&version=2.2&fl=%2A&wt=xml".split("&")))
+        self.assertEqual(query_parse(self.request_body),
+                         query_parse("q=id%3Afoobar&version=2.2&fl=%2A&wt=xml"))
 
     def test_alternate_raw_request(self):
         conn = self.new_connection()
@@ -1520,8 +1525,8 @@ class TestSolrAddingDocuments(SolrBased, RequestTracking, TestAddingDocuments):
         # Add with commit:
         self.conn.add(doc, commit=True, wait_flush=False)
         self.assertEqual(
-            sorted(self.selector().split("&")),
-            sorted("/update?commit=true&waitFlush=false&waitSearcher=false".split("&")))
+            query_parse(self.selector()),
+            query_parse("/update?commit=true&waitFlush=false&waitSearcher=false"))
         # Can't verify the add since we said we weren't going to wait
         # for the flush.
         if six.PY3:
@@ -1534,8 +1539,8 @@ class TestSolrAddingDocuments(SolrBased, RequestTracking, TestAddingDocuments):
         # Add with commit:
         self.conn.add(doc, commit=True, wait_searcher=False)
         self.assertEqual(
-            sorted(self.selector().split("&")),
-            sorted("/update?commit=true&waitSearcher=false".split("&")))
+            query_parse(self.selector()),
+            query_parse("/update?commit=true&waitSearcher=false"))
         # Can't verify the add since we said we weren't going to wait
         # for a searcher.
         if six.PY3:
@@ -1556,8 +1561,8 @@ class TestSolrAddingDocuments(SolrBased, RequestTracking, TestAddingDocuments):
         # Add with optimize:
         self.conn.add_many(documents, commit=True, wait_flush=False)
         self.assertEqual(
-            sorted(self.selector().split("&")),
-            sorted("/update?commit=true&waitFlush=false&waitSearcher=false".split("&")))
+            query_parse(self.selector()),
+            query_parse("/update?commit=true&waitFlush=false&waitSearcher=false"))
         # Can't verify the add since we said we weren't going to wait
         # for the flush.
         if six.PY3:
@@ -1570,8 +1575,8 @@ class TestSolrAddingDocuments(SolrBased, RequestTracking, TestAddingDocuments):
         # Add with optimize:
         self.conn.add_many(documents, commit=True, wait_searcher=False)
         self.assertEqual(
-            sorted(self.selector().split("&")),
-            sorted("/update?commit=true&waitSearcher=false".split("&")))
+            query_parse(self.selector()),
+            query_parse("/update?commit=true&waitSearcher=false"))
         # Can't verify the add since we said we weren't going to wait
         # for a searcher.
         if six.PY3:
@@ -1680,8 +1685,8 @@ class TestSolrDocumentDeletion(SolrBased, RequestTracking,
         self.check_added(doc)
         self.conn.delete(doc["id"], commit=True, wait_flush=False)
         self.assertEqual(
-            sorted(self.selector().split("&")),
-            sorted("/update?commit=true&waitFlush=false&waitSearcher=false".split("&")))
+            query_parse(self.selector()),
+            query_parse("/update?commit=true&waitFlush=false&waitSearcher=false"))
         # Can't verify the add since we said we weren't going to wait
         # for the flush.
         if six.PY3:
@@ -1696,8 +1701,8 @@ class TestSolrDocumentDeletion(SolrBased, RequestTracking,
         self.check_added(doc)
         self.conn.delete(doc["id"], commit=True, wait_searcher=False)
         self.assertEqual(
-            sorted(self.selector().split("&")),
-            sorted("/update?commit=true&waitSearcher=false".split("&")))
+            query_parse(self.selector().split("&")),
+            query_parse("/update?commit=true&waitSearcher=false"))
         # Can't verify the add since we said we weren't going to wait
         # for the flush.
         if six.PY3:

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1208,7 +1208,7 @@ class TestSolrConnectionSearchHandler(SolrConnectionTestCase):
         conn.select("id:foobar", score=False)
         self.assertEqual(self.request_selector, SOLR_PATH + "/select")
         self.assertEqual(sorted(self.request_body.split("&")),
-                         sorted("q=id%3Afoobar&version=2.2&fl=%2A&wt=standard".split("&")))
+                         sorted("q=id%3Afoobar&version=2.2&fl=%2A&wt=xml".split("&")))
 
     def test_select_raw_request(self):
         conn = self.new_connection()
@@ -1222,7 +1222,7 @@ class TestSolrConnectionSearchHandler(SolrConnectionTestCase):
         alternate("id:foobar", score=False)
         self.assertEqual(self.request_selector, SOLR_PATH + "/alternate/path")
         self.assertEqual(sorted(self.request_body.split("&")),
-                         sorted("q=id%3Afoobar&version=2.2&fl=%2A&wt=standard".split("&")))
+                         sorted("q=id%3Afoobar&version=2.2&fl=%2A&wt=xml".split("&")))
 
     def test_alternate_raw_request(self):
         conn = self.new_connection()

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1704,7 +1704,7 @@ class TestSolrDocumentDeletion(SolrBased, RequestTracking,
         self.check_added(doc)
         self.conn.delete(doc["id"], commit=True, wait_searcher=False)
         self.assertEqual(
-            query_parse(self.selector().split("&")),
+            query_parse(self.selector()),
             query_parse("/update?commit=true&waitSearcher=false"))
         # Can't verify the add since we said we weren't going to wait
         # for the flush.

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1520,8 +1520,8 @@ class TestSolrAddingDocuments(SolrBased, RequestTracking, TestAddingDocuments):
         # Add with commit:
         self.conn.add(doc, commit=True, wait_flush=False)
         self.assertEqual(
-            self.selector(),
-            "/update?commit=true&waitFlush=false&waitSearcher=false")
+            sorted(self.selector().split("&")),
+            sorted("/update?commit=true&waitFlush=false&waitSearcher=false".split("&")))
         # Can't verify the add since we said we weren't going to wait
         # for the flush.
         if six.PY3:
@@ -1534,8 +1534,8 @@ class TestSolrAddingDocuments(SolrBased, RequestTracking, TestAddingDocuments):
         # Add with commit:
         self.conn.add(doc, commit=True, wait_searcher=False)
         self.assertEqual(
-            self.selector(),
-            "/update?commit=true&waitSearcher=false")
+            sorted(self.selector().split("&")),
+            sorted("/update?commit=true&waitSearcher=false".split("&")))
         # Can't verify the add since we said we weren't going to wait
         # for a searcher.
         if six.PY3:
@@ -1556,8 +1556,8 @@ class TestSolrAddingDocuments(SolrBased, RequestTracking, TestAddingDocuments):
         # Add with optimize:
         self.conn.add_many(documents, commit=True, wait_flush=False)
         self.assertEqual(
-            self.selector(),
-            "/update?commit=true&waitFlush=false&waitSearcher=false")
+            sorted(self.selector().split("&")),
+            sorted("/update?commit=true&waitFlush=false&waitSearcher=false".split("&")))
         # Can't verify the add since we said we weren't going to wait
         # for the flush.
         if six.PY3:
@@ -1570,8 +1570,8 @@ class TestSolrAddingDocuments(SolrBased, RequestTracking, TestAddingDocuments):
         # Add with optimize:
         self.conn.add_many(documents, commit=True, wait_searcher=False)
         self.assertEqual(
-            self.selector(),
-            "/update?commit=true&waitSearcher=false")
+            sorted(self.selector().split("&")),
+            sorted("/update?commit=true&waitSearcher=false".split("&")))
         # Can't verify the add since we said we weren't going to wait
         # for a searcher.
         if six.PY3:
@@ -1680,8 +1680,8 @@ class TestSolrDocumentDeletion(SolrBased, RequestTracking,
         self.check_added(doc)
         self.conn.delete(doc["id"], commit=True, wait_flush=False)
         self.assertEqual(
-            self.selector(),
-            "/update?commit=true&waitFlush=false&waitSearcher=false")
+            sorted(self.selector().split("&")),
+            sorted("/update?commit=true&waitFlush=false&waitSearcher=false".split("&")))
         # Can't verify the add since we said we weren't going to wait
         # for the flush.
         if six.PY3:
@@ -1696,8 +1696,8 @@ class TestSolrDocumentDeletion(SolrBased, RequestTracking,
         self.check_added(doc)
         self.conn.delete(doc["id"], commit=True, wait_searcher=False)
         self.assertEqual(
-            self.selector(),
-            "/update?commit=true&waitSearcher=false")
+            sorted(self.selector().split("&")),
+            sorted("/update?commit=true&waitSearcher=false".split("&")))
         # Can't verify the add since we said we weren't going to wait
         # for the flush.
         if six.PY3:

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -51,7 +51,7 @@ def query_parse(query_string):
         uri, query_data = query_string.split("?")
         return "{0}?{1}".format(uri, "&".join(sorted(query_data.split("&"))))
     else:
-        return "{0}".format("&".join(sorted(query_data.split("&"))))
+        return "{0}".format("&".join(sorted(query_string.split("&"))))
 
 
 # The names of the following two classes relate specifically to the

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -47,8 +47,11 @@ def get_rand_userdoc(id=None, user_id=None, data=None):
 
 
 def query_parse(query_string):
-    uri, query_data = query_string.split("?")
-    return "{0}?{1}".format(uri, "&".join(sorted(query_data.split("&"))))
+    if "?" in query_string:
+        uri, query_data = query_string.split("?")
+        return "{0}?{1}".format(uri, "&".join(sorted(query_data.split("&"))))
+    else:
+        return "{0}".format("&".join(sorted(query_data.split("&"))))
 
 
 # The names of the following two classes relate specifically to the


### PR DESCRIPTION
In the code we sent two years ago, we were able to use it normally even if the test failed, but this time, we modified it to make the test successful.